### PR TITLE
Heroku SSL/Local workaround

### DIFF
--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1,18 +1,40 @@
-const Sequelize = require('sequelize')
-const pkg = require('../../package.json')
+const Sequelize = require('sequelize');
+const pkg = require('../../package.json');
 
-const databaseName = pkg.name + (process.env.NODE_ENV === 'test' ? '-test' : '')
+const databaseName =
+  pkg.name + (process.env.NODE_ENV === 'test' ? '-test' : '');
 
-const db = new Sequelize(
-  process.env.DATABASE_URL || `postgres://localhost:5432/${databaseName}`,
-  {
+let db;
+if (process.env.DATABASE_URL) {
+  db = new Sequelize(process.env.DATABASE_URL, {
+    dialect: 'postgres',
+    protocol: 'postgres',
+    logging: true,
+    ssl: true,
+  });
+} else {
+  db = new Sequelize(`postgres://localhost:5432/${databaseName}`, {
     logging: false,
-  }
-)
-module.exports = db
+  });
+}
+
+module.exports = db;
 
 // This is a global Mocha hook used for resource cleanup.
 // Otherwise, Mocha v4+ does not exit after tests.
 if (process.env.NODE_ENV === 'test') {
-  after('close database connection', () => db.close())
+  after('close database connection', () => db.close());
 }
+
+// const db = new Sequelize(
+
+//   process.env.DATABASE_URL || `postgres://localhost:5432/${databaseName}`,
+//   {
+//     logging: false,
+//     dialect: 'postgres',
+//     protocol: 'postgres',
+//     dialectOptions: {
+//       ssl: true,
+//     },
+//   }
+// );


### PR DESCRIPTION
change db initialize
add conditional  so  SSL when deployed but not locally
Because Heroku requires SSL encryption but causes error on local run